### PR TITLE
backport frontend changes to v5

### DIFF
--- a/src/_forms.scss
+++ b/src/_forms.scss
@@ -198,6 +198,10 @@ category: Common
     margin: 0 18px 0 0;
 }
 
+.select--telephone-number-country-code {
+    width: 100%;
+}
+
 .label {
     cursor: pointer;
     display: block;
@@ -246,7 +250,7 @@ category: Common
     min-height: ($gs-baseline/3)*40;
 }
 
-.submit-input {
+.submit-input, .submit-input--behaviour {
     background: $pasteup-forms-submit-background;
     border: 0 none;
     color: #ffffff;
@@ -255,7 +259,6 @@ category: Common
     font-size: 14px;
     margin: 0 $gs-gutter 0 0;
     min-width: gs-span(2);
-    padding: 11px $gs-gutter/2;
     outline: none;
     text-align: center;
 
@@ -267,6 +270,10 @@ category: Common
     &:active {
         background: $pasteup-forms-submit-background-active;
     }
+}
+
+.submit-input {
+    padding: 11px $gs-gutter/2;
 }
 
 .submit-input[disabled] {


### PR DESCRIPTION
this should go in as 5.0.8 for frontend

it's changes in https://github.com/guardian/frontend/pull/12338
as well as previous changes in https://github.com/guardian/frontend/pull/11961

I will merge this to the 5.0.master maintenance branch I just created, and then tag it so we can pull into frontend in future.

@OliverJAsh :determined: :elephant: 